### PR TITLE
Use conda list instead of pip freeze

### DIFF
--- a/conda.md
+++ b/conda.md
@@ -67,5 +67,6 @@ Prompt/WSL prompt on Windows). If you are on Windows, I highly recommend using W
 
 11. Now, try running `conda env create -f environment.yml`. Try
     activating the `bestpractices_final` (why is this the name?) environment and running 
-    `python --version`. Try running `pip freeze` to see all the installed 
-    packages. Everything listed at environment.yml should be there. 
+    `python --version`. Try running `conda list` to see all the installed 
+    packages. Everything listed at environment.yml should be there, along with all
+    dependencies. 


### PR DESCRIPTION
Because all the packages are installed from conda and not pip, `pip freeze` output is kinda meh:
```
❯ pip freeze             
colorama @ file:///home/conda/feedstock_root/build_artifacts/colorama_1666700638685/work
coverage @ file:///Users/runner/miniforge3/conda-bld/coverage_1694014009674/work
exceptiongroup @ file:///home/conda/feedstock_root/build_artifacts/exceptiongroup_1692026125334/work
flake8 @ file:///home/conda/feedstock_root/build_artifacts/flake8_1690833614949/work
iniconfig @ file:///home/conda/feedstock_root/build_artifacts/iniconfig_1673103042956/work
mccabe @ file:///home/conda/feedstock_root/build_artifacts/mccabe_1643049622439/work
numpy @ file:///Users/runner/miniforge3/conda-bld/numpy_1687808433287/work
packaging @ file:///home/conda/feedstock_root/build_artifacts/packaging_1681337016113/work
pandas @ file:///Users/runner/miniforge3/conda-bld/pandas_1688740593370/work
pluggy @ file:///home/conda/feedstock_root/build_artifacts/pluggy_1693086607691/work
pycodestyle @ file:///home/conda/feedstock_root/build_artifacts/pycodestyle_1690725416124/work
pyflakes @ file:///home/conda/feedstock_root/build_artifacts/pyflakes_1690656279496/work
pytest @ file:///home/conda/feedstock_root/build_artifacts/pytest_1694128424395/work
python-dateutil @ file:///home/conda/feedstock_root/build_artifacts/python-dateutil_1626286286081/work
pytz @ file:///home/conda/feedstock_root/build_artifacts/pytz_1693930252784/work
six @ file:///home/conda/feedstock_root/build_artifacts/six_1620240208055/work
tomli @ file:///home/conda/feedstock_root/build_artifacts/tomli_1644342247877/work
tzdata @ file:///home/conda/feedstock_root/build_artifacts/python-tzdata_1680081134351/work

```
It's much more informative to use `conda list`:
```
List of packages in environment: "/Users/sobolp/micromamba/envs/bestpractices_final"

  Name             Version       Build                 Channel    
────────────────────────────────────────────────────────────────────
  bzip2            1.0.8         h3422bc3_4            conda-forge
  ca-certificates  2023.7.22     hf0a4a13_0            conda-forge
  colorama         0.4.6         pyhd8ed1ab_0          conda-forge
  coverage         7.3.1         py38hb192615_0        conda-forge
  exceptiongroup   1.1.3         pyhd8ed1ab_0          conda-forge
  flake8           6.1.0         pyhd8ed1ab_0          conda-forge
  iniconfig        2.0.0         pyhd8ed1ab_0          conda-forge
  libblas          3.9.0         18_osxarm64_openblas  conda-forge
  libcblas         3.9.0         18_osxarm64_openblas  conda-forge
  libcxx           16.0.6        h4653b0c_0            conda-forge
  libffi           3.4.2         h3422bc3_5            conda-forge
  libgfortran      5.0.0         13_2_0_hd922786_1     conda-forge
  libgfortran5     13.2.0        hf226fd6_1            conda-forge
  liblapack        3.9.0         18_osxarm64_openblas  conda-forge
  libopenblas      0.3.24        openmp_hd76b1f2_0     conda-forge
  libsqlite        3.43.0        hb31c410_0            conda-forge
  libzlib          1.2.13        h53f4e23_5            conda-forge
  llvm-openmp      16.0.6        h1c12783_0            conda-forge
  mccabe           0.7.0         pyhd8ed1ab_0          conda-forge
  ncurses          6.4           h7ea286d_0            conda-forge
  numpy            1.24.4        py38ha84db1f_0        conda-forge
  openssl          3.1.2         h53f4e23_0            conda-forge
  packaging        23.1          pyhd8ed1ab_0          conda-forge
  pandas           2.0.3         py38hefb543e_1        conda-forge
  pip              23.2.1        pyhd8ed1ab_0          conda-forge
  pluggy           1.3.0         pyhd8ed1ab_0          conda-forge
  pycodestyle      2.11.0        pyhd8ed1ab_0          conda-forge
  pyflakes         3.1.0         pyhd8ed1ab_0          conda-forge
  pytest           7.4.2         pyhd8ed1ab_0          conda-forge
  python           3.8.17        h3ba56d0_0_cpython    conda-forge
  python-dateutil  2.8.2         pyhd8ed1ab_0          conda-forge
  python-tzdata    2023.3        pyhd8ed1ab_0          conda-forge
  python_abi       3.8           3_cp38                conda-forge
  pytz             2023.3.post1  pyhd8ed1ab_0          conda-forge
  readline         8.2           h92ec313_1            conda-forge
  setuptools       68.1.2        pyhd8ed1ab_0          conda-forge
  six              1.16.0        pyh6c4a22f_0          conda-forge
  tk               8.6.12        he1e0b03_0            conda-forge
  tomli            2.0.1         pyhd8ed1ab_0          conda-forge
  wheel            0.41.2        pyhd8ed1ab_0          conda-forge
  xz               5.2.6         h57fd34a_0            conda-forge
```